### PR TITLE
feat: add social sharing buttons to blog posts

### DIFF
--- a/src/components/misc/SocialShare.astro
+++ b/src/components/misc/SocialShare.astro
@@ -1,0 +1,74 @@
+---
+import { Icon } from 'astro-icon/components'
+
+interface Props {
+  title: string
+  url: string
+  class?: string
+}
+
+const { title, url } = Astro.props
+const className = Astro.props.class || ''
+
+const encodedTitle = encodeURIComponent(title)
+const encodedUrl = encodeURIComponent(url)
+
+const shareLinks = {
+  twitter: `https://twitter.com/intent/tweet?text=${encodedTitle}&url=${encodedUrl}`,
+  facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`,
+  linkedin: `https://www.linkedin.com/shareArticle?mini=true&url=${encodedUrl}&title=${encodedTitle}`,
+  reddit: `https://www.reddit.com/submit?url=${encodedUrl}&title=${encodedTitle}`,
+  whatsapp: `https://api.whatsapp.com/send?text=${encodedTitle}%20${encodedUrl}`,
+}
+---
+<div class={`flex gap-2 ${className}`}>
+  <a
+    href={shareLinks.twitter}
+    target="_blank"
+    rel="noopener noreferrer"
+    class="btn-regular w-10 h-10 rounded-xl bg-[var(--btn-regular-bg)] hover:bg-[var(--btn-regular-bg-hover)] active:bg-[var(--btn-regular-bg-active)] active:scale-95"
+    aria-label="Share on Twitter"
+  >
+    <Icon name="fa6-brands:twitter" class="text-[var(--primary)] text-xl" />
+  </a>
+  
+  <a
+    href={shareLinks.facebook}
+    target="_blank"
+    rel="noopener noreferrer"
+    class="btn-regular w-10 h-10 rounded-xl bg-[var(--btn-regular-bg)] hover:bg-[var(--btn-regular-bg-hover)] active:bg-[var(--btn-regular-bg-active)] active:scale-95"
+    aria-label="Share on Facebook"
+  >
+    <Icon name="fa6-brands:facebook" class="text-[var(--primary)] text-xl" />
+  </a>
+  
+  <a
+    href={shareLinks.linkedin}
+    target="_blank"
+    rel="noopener noreferrer"
+    class="btn-regular w-10 h-10 rounded-xl bg-[var(--btn-regular-bg)] hover:bg-[var(--btn-regular-bg-hover)] active:bg-[var(--btn-regular-bg-active)] active:scale-95"
+    aria-label="Share on LinkedIn"
+  >
+    <Icon name="fa6-brands:linkedin" class="text-[var(--primary)] text-xl" />
+  </a>
+  
+  <a
+    href={shareLinks.reddit}
+    target="_blank"
+    rel="noopener noreferrer"
+    class="btn-regular w-10 h-10 rounded-xl bg-[var(--btn-regular-bg)] hover:bg-[var(--btn-regular-bg-hover)] active:bg-[var(--btn-regular-bg-active)] active:scale-95"
+    aria-label="Share on Reddit"
+  >
+    <Icon name="fa6-brands:reddit" class="text-[var(--primary)] text-xl" />
+  </a>
+  
+  <a
+    href={shareLinks.whatsapp}
+    target="_blank"
+    rel="noopener noreferrer"
+    class="btn-regular w-10 h-10 rounded-xl bg-[var(--btn-regular-bg)] hover:bg-[var(--btn-regular-bg-hover)] active:bg-[var(--btn-regular-bg-active)] active:scale-95"
+    aria-label="Share on WhatsApp"
+  >
+    <Icon name="fa6-brands:whatsapp" class="text-[var(--primary)] text-xl" />
+  </a>
+</div> 

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -13,6 +13,7 @@ import PostMetadata from '../../components/PostMeta.astro'
 import ImageWrapper from '../../components/misc/ImageWrapper.astro'
 import { profileConfig, siteConfig } from '../../config'
 import { formatDateToYYYYMMDD } from '../../utils/date-utils'
+import SocialShare from '@components/misc/SocialShare.astro'
 
 export async function getStaticPaths() {
   const blogEntries = await getCollection('posts', ({ data }) => {
@@ -104,6 +105,12 @@ const jsonLd = {
             </Markdown>
 
             {licenseConfig.enable && <License title={entry.data.title} slug={entry.slug} pubDate={entry.data.published} class="mb-6 rounded-xl license-container onload-animation"></License>}
+
+            <SocialShare 
+                title={entry.data.title} 
+                url={Astro.url.toString()} 
+                class="mb-6 onload-animation"
+            />
 
         </div>
     </div>


### PR DESCRIPTION
# Add Social Sharing Buttons to Blog Posts

## Description
Added social sharing functionality to blog posts to improve content distribution and user engagement. Users can now easily share blog posts on Twitter, Facebook, LinkedIn, Reddit, and WhatsApp.

## Changes Made
- Created new `SocialShare.astro` component in `src/components/misc/`
- Added social sharing buttons with proper styling and animations
- Integrated sharing component into blog post template
- Added proper URL encoding for sharing titles and links
- Implemented accessibility features with aria-labels
- Used existing design system variables and classes

## Implementation Details
- Used Astro's component system for modular implementation
- Leveraged existing `astro-icon` package for social media icons
- Maintained consistent styling with the site's design system
- Added proper security attributes for external links
- Ensured responsive design across all screen sizes

## Screenshots
<img width="1501" alt="image" src="https://github.com/user-attachments/assets/71eb206f-f9df-43b4-86f1-1a7d2524d817" />

## Testing Done
- Verified sharing functionality on all supported platforms
- Tested in both light and dark themes
- Checked responsive behaviour on mobile and desktop
- Validated accessibility features
- Tested URL encoding for special characters

## Checklist
- [x] Component follows Astro best practices
- [x] Maintains consistent styling with existing design
- [x] Includes proper security measures for external links
- [x] Implements accessibility features
- [x] Works in both light and dark themes
- [x] Responsive on all screen sizes
- [x] No console errors or warnings
- [x] Code is properly formatted

## Related Issues
Closes #12  - Add social sharing functionality to blog posts

## Reviewes
@Raghav983093 
@Durgesh4993 